### PR TITLE
Fixes the issue with fix_duplication when there are 10 or more duplicates.

### DIFF
--- a/lib/has_permalink.rb
+++ b/lib/has_permalink.rb
@@ -72,8 +72,8 @@ module HasPermalink
           number = 0
 
           links.each_with_index do |link, index|
-            if link.permalink =~ /#{permalink}-\d?$/
-              new_number = link.permalink.match(/-(\d?)$/)[1].to_i
+            if link.permalink =~ /#{permalink}-\d*\.?\d+?$/
+              new_number = link.permalink.match(/-(\d*\.?\d+?)$/)[1].to_i
               number = new_number if new_number > number
             end
           end

--- a/test/has_permalink_test.rb
+++ b/test/has_permalink_test.rb
@@ -134,13 +134,50 @@ class HasPermalinkTest < Test::Unit::TestCase
     u = User.new(:first_name => 'James', :last_name => 'Bond')
     u.save
     assert_equal 'james-bond-3', u.permalink
+
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-4', u.permalink
+    
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-5', u.permalink
+    
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-6', u.permalink
+    
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-7', u.permalink
+    
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-8', u.permalink
+    
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-9', u.permalink
+    
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-10', u.permalink
+    
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-11', u.permalink
+    
+    u = User.new(:first_name => 'James', :last_name => 'Bond')
+    u.save
+    assert_equal 'james-bond-12', u.permalink
+    
   end
 
   def test_auto_fix_duplication_with_integer
     d1 = Department.create!(:name => 'Development')
     assert_equal 'development', d1.permalink
 
-    d2 = Department.create!(:name => 'Development')
+    d2 = Department.create!(:name => 'Development-007')
     assert_equal 'development-007', d2.permalink
   end
 


### PR DESCRIPTION
The regex in fix_duplication method must catch integer instead of digits...

So somethink like james-bond-10 is not caught as the regex tries to look simply for a digit.... and hence wont use permalink james-bond-11 for the 11th duplicate.
