### PR TITLE
Georgian unicode characters

### DIFF
--- a/lib/friendly_url.rb
+++ b/lib/friendly_url.rb
@@ -28,7 +28,7 @@ module FriendlyUrl
       n.gsub!(/[ýÿŷ]/,          'y')
       n.gsub!(/[žżź]/,          'z')
       n.gsub!(/\s+/,            '-')
-      n.gsub!(/[^\sa-z0-9_-]/,  '')
+      n.gsub!(/[^\sa-zა-ჰ0-9_-]/,  '')
       n.gsub!(/-{2,}/,          '-')
       n.gsub!(/^-/,             '')
       n.gsub!(/-$/,             '')


### PR DESCRIPTION
Hello there!

I really like your gem and I'm using it for my current task, which is an organization website.
I live in Georgia (country, not the state), so most articles will have Georgian titles.
So the issue that I have is that your gem replaces all Georgian characters with "", and it means that articles' permalink field will be empty.

And what I did was that I added Georgian language compatibility, so it doesn't replace Georgian unicode characters with "".
I just changed this line in lib/friendly_url.rb:
   n.gsub!(/[^\sa-z0-9_-]/,  '')
to
   n.gsub!(/[^\sa-zა-ჰ0-9_-]/,  '')
("ა" and "ჰ" are the first and the last characters of Georgian alphabet).

The reason why I'm making a pull request and not just changing the gem on my local is that I'll need to set up this website on the server and if you pull my changes, it'll make my life easier.

Thanks in advance.
