### PR TITLE
Generating permalink from rake task for Model inside a module

### DIFF
--- a/lib/tasks/has_permalink.rake
+++ b/lib/tasks/has_permalink.rake
@@ -7,7 +7,7 @@ namespace :has_permalink do
       puts "ERROR: You need to pass the name of the model as an argument."
       puts "Try this: 'rake has_permalink:generate_permalinks[MODEL]'"
     elsif model_name.include?("::")  # Generating permalinks for class inside a module For e.g "ActsAsTaggableOn::Tag"
-      get_class(model_name)      
+      get_class_and_generate_permalink(model_name)      
     else
       generate_permalinks(model_name)
     end
@@ -27,12 +27,12 @@ def generate_permalinks(model_name)
 end
 
 
-def get_class(model_name)
+def get_class_and_generate_permalink(model_name)
   begin
   @model_name=model_name.split("::").inject(Object) do |mod,class_name|
     mod.const_get(class_name)
   end
-  @model_name.generate_permalinks
+  @model_name.generate_permalinks  # adding permalink attribute for existing table
   puts "Congratulations! '#{model_name}' has permalinks!"
    rescue
     rescue_error(model_name)


### PR DESCRIPTION
I was trying to generate permalink for existing table who's permalink attributes where empty somethings like 

``` ruby
rake has_permalink:generate_permalinks ActsAsTaggableOn::Tag
```

Which couldn't generate , so made few changes to the has_permalink.rake so that its accepts something like above 
