### PR TITLE
Don't autofix for the Objects own ID

### DIFF
--- a/lib/has_permalink.rb
+++ b/lib/has_permalink.rb
@@ -53,7 +53,11 @@ module HasPermalink
     # Autofix duplication of permalinks
     def fix_duplication(permalink)
       if auto_fix_duplication
-        n = self.class.where(["permalink = ? AND id != ?", permalink, id]).count
+        n = if id.present?
+          self.class.where(["permalink = ? AND id != ?", permalink, id]).count
+        else
+          self.class.where(["permalink = ?", permalink]).count
+        end
 
         if n > 0
           links = self.class.where(["permalink LIKE ?", "#{permalink}%"]).order("id")


### PR DESCRIPTION
When the model is updated, the current where clause checks against all permalinks for the model including its own ID which will always return true. Therefore it should be excluded as the model can override its own permalink.
