### PR TITLE
Fix bug with deduplication on scoped create

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    has_permalink (0.1.7)
+    has_permalink (0.1.8)
       activerecord (~> 4.0, >= 2.0.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,8 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.3)
     builder (3.2.2)
+    byebug (9.0.6)
+    coderay (1.1.1)
     coveralls (0.8.13)
       json (~> 1.8)
       simplecov (~> 0.11.0)
@@ -31,12 +33,21 @@ GEM
     docile (1.1.5)
     i18n (0.7.0)
     json (1.8.3)
+    method_source (0.8.2)
     minitest (5.8.4)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.1)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     sqlite3 (1.3.11)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
@@ -52,8 +63,9 @@ PLATFORMS
 DEPENDENCIES
   coveralls (~> 0.8.13, >= 0.8.13)
   has_permalink!
+  pry-byebug (>= 3.4.0)
   simplecov (~> 0.11, >= 0.11.2)
   sqlite3 (~> 1.0)
 
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/has_permalink.gemspec
+++ b/has_permalink.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |gem|
   gem.author  = 'Ola Karlsson'
   gem.email   = 'olkarls@gmail.com'
   gem.name    = 'has_permalink'
-  gem.version = '0.1.7'
+  gem.version = '0.1.8'
   gem.summary = 'SEO Permalink Plugin for Ruby on Rails.'
   gem.files = Dir['lib/**/*', 'rails/**/*']
   gem.homepage = 'http://haspermalink.org'

--- a/has_permalink.gemspec
+++ b/has_permalink.gemspec
@@ -11,4 +11,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov', '~> 0.11', '>= 0.11.2'
   gem.add_development_dependency 'coveralls', '~> 0.8.13', '>= 0.8.13'
   gem.add_development_dependency 'sqlite3', '~> 1.0'
+  gem.add_development_dependency 'pry-byebug', '>= 3.4.0'
 end

--- a/lib/has_permalink.rb
+++ b/lib/has_permalink.rb
@@ -53,10 +53,10 @@ module HasPermalink
     # Autofix duplication of permalinks
     def fix_duplication(permalink)
       if auto_fix_duplication
-        n = self.class.where(["permalink = ?", permalink]).count
+        n = self.class.unscoped.where(["permalink = ?", permalink]).count
 
         if n > 0
-          links = self.class.where(["permalink LIKE ?", "#{permalink}%"]).order("id")
+          links = self.class.unscoped.where(["permalink LIKE ?", "#{permalink}%"]).order("id")
 
           number = 0
 

--- a/test/has_permalink_test.rb
+++ b/test/has_permalink_test.rb
@@ -177,6 +177,14 @@ class HasPermalinkTest < Minitest::Test
     assert_equal 'awesome-title', same_page.permalink
   end
 
+  def test_deduplication_for_scoped_create
+    p1 = Page.where(:title => 'Hello Ruby', :other_attribute => 'Rev: 1').create!
+    assert_equal 'hello-ruby', p1.permalink
+
+    p2 = Page.where(:title => 'Hello Ruby', :other_attribute => 'Rev: 2').create!
+    assert_equal 'hello-ruby-1', p2.permalink
+  end
+
   def test_auto_fix_duplication_with_integer
     d1 = Department.create!(:name => 'Development')
     assert_equal 'development', d1.permalink

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 require 'simplecov'
 require 'coveralls'
+require 'pry-byebug'
 
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start


### PR DESCRIPTION
When calling create on a where like `Model.where(name: 'name').create!` has_permalink didn't deduplicate permalinks