### PR TITLE
Add option to not override to param

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    has_permalink (0.1.8)
+    has_permalink (0.2.0)
       activerecord (~> 4.0, >= 2.0.0)
 
 GEM

--- a/has_permalink.gemspec
+++ b/has_permalink.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |gem|
   gem.author  = 'Ola Karlsson'
   gem.email   = 'olkarls@gmail.com'
   gem.name    = 'has_permalink'
-  gem.version = '0.1.8'
+  gem.version = '0.2.0'
   gem.summary = 'SEO Permalink Plugin for Ruby on Rails.'
   gem.files = Dir['lib/**/*', 'rails/**/*']
   gem.homepage = 'http://haspermalink.org'

--- a/has_permalink.gemspec
+++ b/has_permalink.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.files = Dir['lib/**/*', 'rails/**/*']
   gem.homepage = 'http://haspermalink.org'
   gem.licenses = ['MIT']
+  gem.required_ruby_version = '>= 2.0'
   gem.add_runtime_dependency 'activerecord', '~> 4.0', '>= 2.0.0'
   gem.add_development_dependency 'simplecov', '~> 0.11', '>= 0.11.2'
   gem.add_development_dependency 'coveralls', '~> 0.8.13', '>= 0.8.13'

--- a/lib/has_permalink.rb
+++ b/lib/has_permalink.rb
@@ -3,16 +3,18 @@ require 'friendly_url'
 module HasPermalink
   require 'railtie' if defined?(Rails) && Rails.version >= "3"
 
-  def has_permalink(generate_from = :title, auto_fix_duplication = false)
+  def has_permalink(generate_from = :title, auto_fix_duplication: false, to_param_returns_permalink: true)
     unless included_modules.include? InstanceMethods
       class_attribute :generate_from
       class_attribute :auto_fix_duplication
+      class_attribute :to_param_returns_permalink
       extend ClassMethods
       include InstanceMethods
     end
 
     self.generate_from        = generate_from
     self.auto_fix_duplication = auto_fix_duplication
+    self.to_param_returns_permalink = to_param_returns_permalink
     before_validation :generate_permalink
   end
 
@@ -45,7 +47,8 @@ module HasPermalink
 
     # Override to send permalink as params[:id]
     def to_param
-      permalink
+      return permalink if to_param_returns_permalink
+      super
     end
 
     private

--- a/test/has_permalink_test.rb
+++ b/test/has_permalink_test.rb
@@ -10,7 +10,7 @@ class HasPermalinkTest < Minitest::Test
   end
 
   class Page < ActiveRecord::Base
-    has_permalink(:title, true)
+    has_permalink(:title, auto_fix_duplication: true, to_param_returns_permalink: true)
   end
 
   class Category < ActiveRecord::Base
@@ -22,7 +22,7 @@ class HasPermalinkTest < Minitest::Test
   end
 
   class User < ActiveRecord::Base
-    has_permalink(:name, true)
+    has_permalink(:name, auto_fix_duplication: true, to_param_returns_permalink: false)
 
     def name
       "#{first_name} #{last_name}"
@@ -30,7 +30,7 @@ class HasPermalinkTest < Minitest::Test
   end
 
   class Department < ActiveRecord::Base
-    has_permalink(:name, true)
+    has_permalink(:name, auto_fix_duplication: true)
 
     def resolve_duplication(permalink, number)
       "#{permalink}-007"
@@ -249,5 +249,15 @@ class HasPermalinkTest < Minitest::Test
     post = Post.find('1')
 
     refute_nil post
+  end
+
+  def test_to_param_to_returns_permalink
+    page = Page.create(:title => 'Permalink Title')
+    assert_equal 'permalink-title', page.to_param
+  end
+
+  def test_to_param_to_returns_id
+    user = User.create(:first_name => 'Tom', :last_name => 'Hanks')
+    assert_equal user.id.to_s, user.to_param
   end
 end


### PR DESCRIPTION
We wanted to have option of not overriding the original implementation of `to_param` to return permalink. In this pull request I added an additional argument `to_param_returns_permalink` based on which the overriden `to_param` returns either `permalink` or the default value.

Together with this I switched the has_permalink attributes to keyword arguments and set the required ruby version to ruby 2.0. Due to the `has_permalink` attributes change I bumped the version to 2.0.