### PR TITLE
Fixing `ActiveRecord::Migration is not supported.` error in Rails 5

### DIFF
--- a/has_permalink.gemspec
+++ b/has_permalink.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.homepage = 'http://haspermalink.org'
   gem.licenses = ['MIT']
   gem.required_ruby_version = '>= 2.0'
-  gem.add_runtime_dependency 'activerecord', '~> 4.0', '>= 2.0.0'
+  gem.add_runtime_dependency 'activerecord', '>= 2.0.0'
   gem.add_development_dependency 'simplecov', '~> 0.11', '>= 0.11.2'
   gem.add_development_dependency 'coveralls', '~> 0.8.13', '>= 0.8.13'
   gem.add_development_dependency 'sqlite3', '~> 1.0'

--- a/lib/generators/templates/has_permalink_migration.rb.erb
+++ b/lib/generators/templates/has_permalink_migration.rb.erb
@@ -1,9 +1,6 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
-  def self.up
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= Rails.version.first(3) %>]
+  def change
     add_column :<%= name.underscore.camelize.tableize %>, :permalink, :string
     add_index :<%= name.underscore.camelize.tableize %>, :permalink
-  end
-  def self.down
-    remove_column :<%= name.underscore.camelize.tableize %>, :permalink
   end
 end


### PR DESCRIPTION
`StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:`

Also changed the migration format to the new `def change`